### PR TITLE
Add exception to Metashare query to include a specific CIP dataset

### DIFF
--- a/src/main/java/au/vic/delwp/FileXMLWriter.java
+++ b/src/main/java/au/vic/delwp/FileXMLWriter.java
@@ -101,7 +101,7 @@ public class FileXMLWriter {
 	  HashSet uuidSet = new HashSet();
 	
 		/* Fetch list of (or iterator over?) datasets from Oracle DB */
-		String HQL = "FROM Dataset WHERE ( ANZLIC_ID IS NOT NULL AND name IS NOT NULL AND title IS NOT NULL AND NAME NOT LIKE 'CIP%' )"; // Build a HQL query string from command line arguments plus some default
+		String HQL = "FROM Dataset WHERE ( ANZLIC_ID IS NOT NULL AND name IS NOT NULL AND title IS NOT NULL AND (NAME = 'CIP_PROJECT_STATUS' or NAME NOT LIKE 'CIP%' ))"; // Build a HQL query string from command line arguments plus some default
 		if( cmd.hasOption("q")) {
       String query = cmd.getOptionValue("q");
       if (query.matches(".*\\S+.*")) HQL += " AND " + query;


### PR DESCRIPTION
There is a general exclusion of Metashare datasets with CIP in the name to remove duplicates with Raster Meta, however there is one vector dataset named CIP_PROJECT_STATUS being incorrectly excluded and which DELWP requires